### PR TITLE
[go] Pass plugins argument through to go_proto_compile and go_grpc_compile

### DIFF
--- a/go/go_grpc_library.bzl
+++ b/go/go_grpc_library.bzl
@@ -5,6 +5,7 @@ load("//go:utils.bzl", "get_importmappings")
 def go_grpc_library(**kwargs):
     name = kwargs.get("name")
     deps = kwargs.get("deps")
+    plugins = kwargs.get("plugins", [])
     importpath = kwargs.get("importpath")
     visibility = kwargs.get("visibility")
     go_deps = kwargs.get("go_deps", [])
@@ -14,6 +15,7 @@ def go_grpc_library(**kwargs):
     go_grpc_compile(
         name = name_pb,
         deps = deps,
+        plugins = plugins,
         plugin_options = get_importmappings(kwargs.pop("importmap", {})),
         visibility = visibility,
         verbose = kwargs.pop("verbose", 0),

--- a/go/go_proto_library.bzl
+++ b/go/go_proto_library.bzl
@@ -5,6 +5,7 @@ load("//go:utils.bzl", "get_importmappings")
 def go_proto_library(**kwargs):
     name = kwargs.get("name")
     deps = kwargs.get("deps")
+    plugins = kwargs.get("plugins", [])
     importpath = kwargs.get("importpath")
     visibility = kwargs.get("visibility")
     go_deps = kwargs.get("go_deps", [])
@@ -14,6 +15,7 @@ def go_proto_library(**kwargs):
     go_proto_compile(
         name = name_pb,
         deps = deps,
+        plugins = plugins,
         plugin_options = get_importmappings(kwargs.pop("importmap", {})),
         visibility = visibility,
         verbose = kwargs.pop("verbose", 0),


### PR DESCRIPTION
Previously, `go_proto_library` and `go_grpc_library` were dropping the `plugins` argument before calling `*_compile`, so plugins weren't working